### PR TITLE
OVE_OS_ID_LIKE defaults to OVE_OS_ID with /etc/os-release

### DIFF
--- a/ove
+++ b/ove
@@ -11089,7 +11089,7 @@ function ove_determine_dist_version_and_pack_manager {
 	if [ -e /etc/os-release ]; then
 		OVE_OS=$(source /etc/os-release; echo ${NAME})
 		OVE_OS_ID=$(source /etc/os-release; echo ${ID})
-		OVE_OS_ID_LIKE=$(source /etc/os-release; echo ${ID_LIKE})
+		OVE_OS_ID_LIKE=$(source /etc/os-release; echo ${ID_LIKE:-$ID})
 		OVE_OS_VER=$(source /etc/os-release; echo ${VERSION_ID})
 	elif command -v lsb_release > /dev/null; then
 		OVE_OS=$(${ove_cmd2pathname["lsb_release"]:?} --id --short)


### PR DESCRIPTION
This is one possible fix for `OVE_OS_ID_LIKE=""` on Debian/sid, which breaks e.g. the DMCE dist script.